### PR TITLE
Analytic for domain trust discovery with nltest

### DIFF
--- a/eqllib/analytics/discovery/T1482-domain-trust-discovery-nltest.toml
+++ b/eqllib/analytics/discovery/T1482-domain-trust-discovery-nltest.toml
@@ -1,0 +1,19 @@
+[analytic.metadata]
+categories = ["hunt"]
+confidence = "low"
+contributors = ["Tony Lambert"]
+created_date = "05/17/2019"
+description = "Identifies execution of nltest.exe for domain trust discovery. This technique is used by attackers to enumerate Active Directory trusts."
+id = "0d49771a-792c-11e9-8f5c-d46d6d62a49e"
+name = "Domain Trust Discovery via Nltest.exe"
+os = ["windows"]
+tactics = ["Discovery"]
+tags = ["atomicblue"]
+techniques = ["T1482"]
+updated_date = "05/17/2019"
+
+[analytic]
+query = '''
+process where subtype.create and
+  process_name == "nltest.exe" and command_line == "*domain_trusts*"
+'''


### PR DESCRIPTION
Analytic for domain trust discovery using nltest.exe. This has been observed in Trickbot infections.